### PR TITLE
Require specifying the release branch to release from

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,12 @@ name: Release Charts
 
 on:
   workflow_dispatch:
+    inputs:
+      spiceai_branch:
+        description: 'Release branch in spiceai/spiceai'
+        required: true
+        default: 'release/1.X'
+        type: string
 
 jobs:
   release:
@@ -22,6 +28,7 @@ jobs:
         with:
           path: spiceai
           repository: spiceai/spiceai
+          ref: ${{ github.event.inputs.spiceai_branch }}
           fetch-depth: 0
 
       - name: Configure Git
@@ -35,7 +42,7 @@ jobs:
 
       - name: Install chart-releaser
         uses: ./helm-charts/.github/actions/chart-releaser-installer
-      
+
       - name: Release Charts
         working-directory: helm-charts
         env:


### PR DESCRIPTION
## 🗣 Description

We should release the Helm chart from the same release branch that the binaries are released from.